### PR TITLE
Fixed comments to align more appropriately with the number of defined…

### DIFF
--- a/drivers/gpio/gpio-ts7800-v2.c
+++ b/drivers/gpio/gpio-ts7800-v2.c
@@ -27,7 +27,7 @@ struct ts7800v2_gpio_priv {
 	void __iomem  *syscon;
 	struct gpio_chip gpio_chip;
 	spinlock_t lock;
-	/* direction[4] is enough for all 118 DIOs (up to 128), 1=in, 0=out */
+	/* direction[4] is enough for 128 DIOs, 1=in, 0=out */
 	unsigned int direction[4];
 	unsigned int ovalue[4];
 };


### PR DESCRIPTION
Fixed comments in TS-7800-V2 GPIO driver to more accurately match the defined number of GPIO.